### PR TITLE
Fix sdk settings item icon docs

### DIFF
--- a/docs/docs/guide/2_api-reference/ui/settingsItem.md
+++ b/docs/docs/guide/2_api-reference/ui/settingsItem.md
@@ -9,7 +9,7 @@ A specific view or a set of actions can be triggered based on the `locationId`.
 ui.settings.addSettingsItem({
     label: 'App Settings',
     locationId: 'settings-location-id',
-    icon: 'default-object-books',
+    icon: 'regular-AR',
     displaySearchBar: true,
     tab: 'plugins',
 });
@@ -39,7 +39,7 @@ if (location.is(location.MAIN_HIDDEN)) {
     ui.settings.addSettingsItem({
         label: 'App Settings',
         locationId: 'settings-location-id',
-        icon: 'default-object-books',
+        icon: 'regular-AR',
         displaySearchBar: true,
         tab: 'plugins',
     });


### PR DESCRIPTION
![image](https://github.com/shopware/meteor-admin-sdk/assets/39218577/cee7d325-ebee-40f3-9b0e-630ce49e8b1f)