### PR TITLE
NEXT-33826 - fix error throwing in subscribtions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## [4.0.2] - 20.02.2024
+
+## Fixed
+- `data.subscribe` throws now correctly an error if privileges are missing
+
 ## [4.0.0] - 07.02.2024
 
 ## Changed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@shopware-ag/meteor-admin-sdk",
-  "version": "4.0.0",
+  "version": "4.0.2",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@shopware-ag/meteor-admin-sdk",
-      "version": "4.0.0",
+      "version": "4.0.2",
       "license": "MIT",
       "dependencies": {
         "localforage": "^1.10.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@shopware-ag/meteor-admin-sdk",
   "license": "MIT",
-  "version": "4.0.1",
+  "version": "4.0.2",
   "repository": {
     "type": "git",
     "url": "git://github.com/shopware/meteor-admin-sdk.git"
@@ -77,7 +77,7 @@
     "lint:eslint": "eslint ./src --ext .ts",
     "test": "jest --collectCoverage",
     "test:watch": "jest --watch",
-    "e2e": "concurrently --handle-input --kill-others --success first \"npm run dev\" \"wait-on http://127.0.0.1:8181 && wait-on http://127.0.0.1:8182 && playwright test\"",
+    "e2e": "NODE_ENV=production concurrently --handle-input --kill-others --success first --names \"DEV,TEST\" \"npm run dev\" \"wait-on http://127.0.0.1:8181 && wait-on http://127.0.0.1:8182 && playwright test\"",
     "e2e:dev": "playwright test --project=chromium --reporter=list",
     "e2e:dev-watch": "chokidar \"{e2e,src}/**/*.{js,ts}\" -c 'clear && npm run e2e:dev' --initial",
     "e2e:dev-debug": "PWDEBUG=1 npm run e2e:dev",

--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,4 +1,5 @@
 import { createHandler, createSender, processDataRegistration, send, subscribe as createSubscriber } from '../channel';
+import MissingPrivilegesError from '../privileges/missing-privileges-error';
 import Criteria from './Criteria';
 import Entity from './_internals/Entity';
 import EntityCollection from './_internals/EntityCollection';
@@ -31,6 +32,11 @@ function createFilteredSubscriber(type: 'datasetSubscribe' | 'datasetUpdate') {
         if (options?.selectors?.sort().join(',') !== data.selectors.sort().join(',')) {
           return;
         }
+      }
+
+      // Check if data.data is an error and log it
+      if (data?.data instanceof MissingPrivilegesError) {
+        console.error(data.data);
       }
 
       const returnValue = callback(data);


### PR DESCRIPTION
If the subscriber data contains an error it wasn't thrown correctly and therefore the developer couldn't see it. Now it throws privileges errors also correctly at subscriptions.